### PR TITLE
Use size of the typed array instead of underlying bufffer

### DIFF
--- a/include/addon-tools.hpp
+++ b/include/addon-tools.hpp
@@ -338,7 +338,7 @@ inline Type* getArrayData(
 		size_t offset = ta.ByteOffset();
 		Napi::ArrayBuffer arr = ta.ArrayBuffer();
 		if (num) {
-			*num = arr.ByteLength() / sizeof(Type);
+			*num = ta.ByteLength() / sizeof(Type);
 		}
 		uint8_t *base = reinterpret_cast<uint8_t *>(arr.Data());
 		out = reinterpret_cast<Type *>(base + offset);


### PR DESCRIPTION
If an array is subarrayed from another array they will still have the same underlying buffer giving the wrong size here